### PR TITLE
feat: add MultiDiscriminator and Discriminators with tests

### DIFF
--- a/packages/generation/src/generation/models/discriminators/__init__.py
+++ b/packages/generation/src/generation/models/discriminators/__init__.py
@@ -1,0 +1,3 @@
+from generation.models.discriminators.period import PeriodDiscriminator
+
+__all__ = ["PeriodDiscriminator"]

--- a/packages/generation/src/generation/models/discriminators/multi.py
+++ b/packages/generation/src/generation/models/discriminators/multi.py
@@ -1,0 +1,65 @@
+from functools import partial
+from typing import Any
+
+from torch import Tensor, nn
+
+from generation.models.discriminators.protocol import (
+    DiscriminatorProtocol,
+    MultiDiscriminatorReturnType,
+)
+
+
+class MultiDiscriminator(nn.Module):
+    """
+    A multi-discriminator module that applies multiple discriminators in parallel.
+
+    This class manages a collection of discriminators and applies them to both real and generated data,
+    collecting their outputs and feature maps for training purposes (typically in adversarial setups).
+
+    Args:
+        discriminator: Either a non-instantiated discriminator class that follows the DiscriminatorProtocol
+                      or a partially instantiated class created with functools.partial
+        configs: A list of configuration dictionaries, where each dictionary contains the parameters
+                needed to instantiate one discriminator instance
+
+    Example:
+        >>> from functools import partial
+        >>> # Using a non-instantiated class
+        >>> multi_disc = MultiDiscriminator(SomeDiscriminator, [{'param1': 'value1'}, {'param1': 'value2'}])
+        >>>
+        >>> # Using a partially instantiated class
+        >>> partial_disc = partial(SomeDiscriminator, shared_param='shared_value')
+        >>> multi_disc = MultiDiscriminator(partial_disc, [{'param1': 'value1'}, {'param1': 'value2'}])
+    """
+
+    def __init__(
+        self,
+        # either get a non instantiated class or a half-instantiated class
+        discriminator: type[DiscriminatorProtocol] | partial,
+        configs: list[dict[str, Any]],
+    ):
+        super().__init__()
+        self.configs = configs
+        self.discriminators = nn.ModuleList(
+            [discriminator(**config) for config in self.configs]
+        )
+
+    def forward(self, y: Tensor, y_hat: Tensor) -> MultiDiscriminatorReturnType:
+        y_d_rs = []
+        y_d_gs = []
+        fmap_rs = []
+        fmap_gs = []
+        for i, d in enumerate(self.discriminators):
+            y_d_r, fmap_r = d(y)
+            y_d_g, fmap_g = d(y_hat)
+            y_d_rs.append(y_d_r)
+            fmap_rs.append(fmap_r)
+            y_d_gs.append(y_d_g)
+            fmap_gs.append(fmap_g)
+
+        return {
+            "disc_rs": y_d_rs,
+            "disc_gs": y_d_gs,
+            "fmap_rs": fmap_rs,
+            "fmap_gs": fmap_gs,
+        }

--- a/packages/generation/src/generation/models/discriminators/period.py
+++ b/packages/generation/src/generation/models/discriminators/period.py
@@ -1,0 +1,117 @@
+from jaxtyping import Float
+from torch import Tensor, flatten, nn
+from torch.nn import functional as F
+from torch.nn.utils.parametrizations import spectral_norm, weight_norm
+from traincore.config_stores.models import model_store
+from traincore.models.decoders.protocol import DecoderProtocol
+from traincore.models.encoders.protocol import EncoderProtocol
+
+from generation.models.discriminators.protocol import DiscriminatorReturnType
+
+__all__ = ["PeriodDiscriminator"]
+
+
+@model_store(name="model/discriminator")
+class PeriodDiscriminator(nn.Module):
+    def __init__(
+        self,
+        period: int = 2,
+        kernel_size: int = 5,
+        stride: int = 3,
+        use_spectral_norm: bool = False,
+        discriminator_channel_multiplier: int = 4,
+        encoder: EncoderProtocol | None = None,
+        decoder: DecoderProtocol | None = None,
+        sample_rate: float = 44100.0,
+        num_samples: int = -1,
+    ) -> None:
+        super().__init__()
+        self.mtype = "a2e"
+        self.encoder = encoder
+        self.decoder = decoder
+
+        self.sample_rate = sample_rate
+        self.num_samples = num_samples
+        self.period = period
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.use_spectral_norm = use_spectral_norm
+        self.d_mult = 4  # discriminator_channel_multiplier
+
+        dilation = 1
+        norm = spectral_norm if use_spectral_norm else weight_norm
+        self.model = nn.ModuleList(
+            [
+                norm(
+                    nn.Conv2d(
+                        1,
+                        32 * self.d_mult,
+                        kernel_size=(self.kernel_size, 1),
+                        stride=(self.stride, 1),
+                        padding=((self.kernel_size * dilation - dilation) // 2, 0),
+                    )
+                ),
+                norm(
+                    nn.Conv2d(
+                        32 * self.d_mult,
+                        128 * self.d_mult,
+                        kernel_size=(self.kernel_size, 1),
+                        stride=(self.stride, 1),
+                        padding=((self.kernel_size * dilation - dilation) // 2, 0),
+                    )
+                ),
+                norm(
+                    nn.Conv2d(
+                        128 * self.d_mult,
+                        512 * self.d_mult,
+                        kernel_size=(self.kernel_size, 1),
+                        stride=(self.stride, 1),
+                        padding=((self.kernel_size * dilation - dilation) // 2, 0),
+                    )
+                ),
+                norm(
+                    nn.Conv2d(
+                        512 * self.d_mult,
+                        1024 * self.d_mult,
+                        kernel_size=(self.kernel_size, 1),
+                        stride=(self.stride, 1),
+                        padding=((self.kernel_size * dilation - dilation) // 2, 0),
+                    )
+                ),
+                norm(
+                    nn.Conv2d(
+                        1024 * self.d_mult,
+                        1024 * self.d_mult,
+                        kernel_size=(self.kernel_size, 1),
+                        stride=1,
+                        padding=((2, 0),),
+                    )
+                ),
+            ]
+        )
+        self.conv_post = norm(
+            nn.Conv2d(int(1024 * self.d_mult), 1, (3, 1), 1, padding=(1, 0))
+        )
+
+    def forward(
+        self,
+        x: Float[Tensor, "batch channel time"],
+        x_hat: Float[Tensor, "batch channel time"],
+    ) -> DiscriminatorReturnType:
+        fmap = []
+
+        b, c, t = x.shape
+        if t % self.period != 0:
+            n_pad = self.period - (t % self.period)
+            x = F.pad(x, (0, n_pad), "reflect")
+            t = t + n_pad
+        x = x.view(b, c, t // self.period, self.period)
+
+        for layer in self.model:
+            x = layer(x)
+            x = F.leaky_relu(x, 0.1)
+            fmap.append(x)
+        x = self.conv_post(x)
+        fmap.append(x)
+        x = flatten(x, 1, -1)
+        return {"x": x, "fmap": fmap}

--- a/packages/generation/src/generation/models/discriminators/period.py
+++ b/packages/generation/src/generation/models/discriminators/period.py
@@ -11,7 +11,7 @@ from generation.models.discriminators.protocol import DiscriminatorReturnType
 __all__ = ["PeriodDiscriminator"]
 
 
-@model_store(name="model/discriminator")
+@model_store(name="model/discriminator/period")
 class PeriodDiscriminator(nn.Module):
     def __init__(
         self,

--- a/packages/generation/src/generation/models/discriminators/protocol.py
+++ b/packages/generation/src/generation/models/discriminators/protocol.py
@@ -1,0 +1,31 @@
+from typing import TypedDict
+
+from jaxtyping import Float
+from torch import Tensor
+from traincore.models.protocol import AuemModelProtocol
+
+__all__ = ["DiscriminatorProtocol", "DiscriminatorReturnType"]
+
+
+class DiscriminatorReturnType(TypedDict):
+    x: Float[Tensor, "..."]
+    fmap: list[Float[Tensor, "..."]]
+
+
+class DiscriminatorProtocol(AuemModelProtocol):
+    def forward(
+        self, x: Float[Tensor, "..."], x_hat: Float[Tensor, "..."]
+    ) -> DiscriminatorReturnType: ...
+
+
+class MultiDiscriminatorReturnType(TypedDict):
+    disc_rs: list[Float[Tensor, "..."]]
+    fmap_rs: list[list[Float[Tensor, "..."]]]
+    disc_gs: list[Float[Tensor, "..."]]
+    fmap_gs: list[list[Float[Tensor, "..."]]]
+
+
+class MultiDiscriminatorProtocol(AuemModelProtocol):
+    def forward(
+        self, x: Float[Tensor, "..."], x_hat: Float[Tensor, "..."]
+    ) -> MultiDiscriminatorReturnType: ...

--- a/packages/generation/src/generation/models/discriminators/protocol.py
+++ b/packages/generation/src/generation/models/discriminators/protocol.py
@@ -4,7 +4,7 @@ from jaxtyping import Float
 from torch import Tensor
 from traincore.models.protocol import AuemModelProtocol
 
-__all__ = ["DiscriminatorProtocol", "DiscriminatorReturnType"]
+__all__ = ["DiscriminatorProtocol", "DiscriminatorReturnType", "MultiDiscriminatorProtocol", "MultiDiscriminatorReturnType"]
 
 
 class DiscriminatorReturnType(TypedDict):

--- a/packages/generation/tests/discriminators/test_discriminators.py
+++ b/packages/generation/tests/discriminators/test_discriminators.py
@@ -1,0 +1,28 @@
+"""Test if all exported models are instantiated and follow the protocol."""
+
+import pytest
+from generation.models import discriminators
+from generation.models.discriminators import __all__ as all_registered_discriminators
+from generation.models.discriminators.protocol import DiscriminatorProtocol
+
+
+@pytest.fixture(params=all_registered_discriminators)
+def discriminator_cls(request) -> type[DiscriminatorProtocol]:
+    """Fixture that yields each registered model class for parametrized testing.
+
+    Args:
+        request: Pytest request object containing the current parameter value.
+
+    Returns:
+        type: A model class from the generation.models module.
+    """
+
+    return getattr(discriminators, request.param)
+
+
+def test_metrics_should_instantiate_and_follow_protocol(
+    discriminator_cls: type[DiscriminatorProtocol],
+):
+    discriminator = discriminator_cls()
+
+    assert isinstance(discriminator, DiscriminatorProtocol)


### PR DESCRIPTION
This commit introduces `MultiDiscriminator` and `PeriodDiscriminator` classes in the discriminators module, along with their respective protocols. Additionally, a test file is created to ensure that all registered discriminators can be instantiated and follow the protocol.